### PR TITLE
Add compat bound for FillArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LowRankMatricesFillArraysExt = "FillArrays"
 
 [compat]
+FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
The bounds are copied over from `LowRankApprox.jl`. Tests passed locally for me for all versions added here.