### PR TITLE
Support multiplication of sparse matrices and low rank matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,21 +9,25 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extensions]
 LowRankMatricesFillArraysExt = "FillArrays"
+LowRankMatricesSparseArraysExt = "SparseArrays"
 
 [compat]
 Aqua = "0.8"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"
 LinearAlgebra = "<0.0.1, 1"
+SparseArrays = "1"
 Test = "<0.0.1, 1"
 julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "FillArrays"]
+test = ["Aqua", "Test", "FillArrays", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ LowRankMatricesSparseArraysExt = "SparseArrays"
 Aqua = "0.8"
 FillArrays = "0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 1"
 LinearAlgebra = "<0.0.1, 1"
-SparseArrays = "1"
+SparseArrays = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 julia = "1"
 

--- a/ext/LowRankMatricesSparseArraysExt.jl
+++ b/ext/LowRankMatricesSparseArraysExt.jl
@@ -1,19 +1,13 @@
 module LowRankMatricesSparseArraysExt
 
-using LowRankMatrices: LowRankMatrix
+using LowRankMatrices: LowRankMatrix, lowrankmul
 using SparseArrays: SparseMatrixCSC
-using LinearAlgebra: rank, mul!
 
 function Base.:*(L::LowRankMatrix, A::SparseMatrixCSC)
-    V = zeros(promote_type(eltype(L), eltype(A)), size(A, 2), rank(L))
-    mul!(V, transpose(A), L.V)
-    LowRankMatrix(copy(L.U), V)
+    lowrankmul(L,A)
 end
-
 function Base.:*(A::SparseMatrixCSC, L::LowRankMatrix)
-    U = zeros(promote_type(eltype(A), eltype(L)), size(A, 1), rank(L))
-    mul!(U, A, L.U)
-    LowRankMatrix(U, copy(L.V))
+    lowrankmul(A,L)
 end
 
 end

--- a/ext/LowRankMatricesSparseArraysExt.jl
+++ b/ext/LowRankMatricesSparseArraysExt.jl
@@ -1,0 +1,19 @@
+module LowRankMatricesSparseArraysExt
+
+using LowRankMatrices: LowRankMatrix
+using SparseArrays: SparseMatrixCSC
+using LinearAlgebra: rank, mul!
+
+function Base.:*(L::LowRankMatrix, A::SparseMatrixCSC)
+    V = zeros(promote_type(eltype(L), eltype(A)), size(A, 2), rank(L))
+    mul!(V, transpose(A), L.V)
+    LowRankMatrix(copy(L.U), V)
+end
+
+function Base.:*(A::SparseMatrixCSC, L::LowRankMatrix)
+    U = zeros(promote_type(eltype(A), eltype(L)), size(A, 1), rank(L))
+    mul!(U, A, L.U)
+    LowRankMatrix(U, copy(L.V))
+end
+
+end

--- a/src/LowRankMatrices.jl
+++ b/src/LowRankMatrices.jl
@@ -13,6 +13,7 @@ include("lowrankmatrix.jl")
 
 if !isdefined(Base, :get_extension)
     include("../ext/LowRankMatricesFillArraysExt.jl")
+    include("../ext/LowRankMatricesSparseArraysExt.jl")
 end
 
 end

--- a/src/lowrankmatrix.jl
+++ b/src/lowrankmatrix.jl
@@ -144,7 +144,18 @@ function mul!(b::AbstractVector, L::LowRankMatrix, x::AbstractVector)
     mul!(b, L.U, temp)
     b
 end
+
 function *(L::LowRankMatrix, M::LowRankMatrix)
+    lowrankmul(L,M)
+end
+function *(L::LowRankMatrix, A::Matrix)
+    lowrankmul(L,A)
+end
+function *(A::Matrix, L::LowRankMatrix)
+    lowrankmul(A,L)
+end
+
+function lowrankmul(L::LowRankMatrix, M::LowRankMatrix)
     T = promote_type(eltype(L),eltype(M))
     temp = zeros(T,rank(L),rank(M))
     mul!(temp, transpose(L.V), M.U)
@@ -153,17 +164,13 @@ function *(L::LowRankMatrix, M::LowRankMatrix)
     LowRankMatrix(copy(L.U),V)
 end
 
-
-
-function *(L::LowRankMatrix, A::Matrix)
+function lowrankmul(L::LowRankMatrix, A::AbstractMatrix)
     V = zeros(promote_type(eltype(L),eltype(A)),size(A,2),rank(L))
     mul!(V, transpose(A), L.V)
     LowRankMatrix(copy(L.U),V)
 end
 
-
-
-function *(A::Matrix, L::LowRankMatrix)
+function lowrankmul(A::AbstractMatrix, L::LowRankMatrix)
     U = zeros(promote_type(eltype(A),eltype(L)),size(A,1),rank(L))
     mul!(U,A,L.U)
     LowRankMatrix(U,copy(L.V))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using LowRankMatrices
 using Test
 using LinearAlgebra
 using FillArrays
+using SparseArrays
 
 if VERSION >= v"1.10"
     include("aqua.jl")
@@ -101,3 +102,11 @@ end
     @test A*v ≈ Matrix(A)*v
 end
 
+@testset "SparseMatrixCSC * LowRankMatrix" begin
+    A = LowRankMatrices._LowRankMatrix(randn(20,4), randn(12,4))
+    S = sparse(randn(12,20))
+    @test A*S isa LowRankMatrix
+    @test S*A isa LowRankMatrix
+    @test A*S ≈ Matrix(A)*Matrix(S)
+    @test S*A ≈ Matrix(S)*Matrix(A)
+end


### PR DESCRIPTION
Currently, multiplication of sparse matrices and LowRankMatrices errors. But the code used for the dense case can in principle be used for any AbstractMatrix. Though naively dispatching on that results in ambiguities.

This PR moves this code to a new function `lowrankmul` which takes any AbstractMatrix as argument. Then `*` dispatches to `lowrankmul` for the type Matrix and now with the extension also for SparseMatrixCSC. 